### PR TITLE
ADD greetings and REMOVED lost in translation e.g. mosto=must=grape must

### DIFF
--- a/stopwords-it.txt
+++ b/stopwords-it.txt
@@ -83,7 +83,6 @@ brava
 bravo
 buono
 c
-casa
 caso
 cento
 certa
@@ -98,15 +97,13 @@ ci
 ciascuna
 ciascuno
 cima
+ciao
 cinque
 cio
 cioe
 cioã¨
 cioè
 circa
-citta
-città
-cittã
 ciã²
 ciò
 co
@@ -271,6 +268,7 @@ futuro
 generale
 gente
 gia
+gi
 giacche
 giorni
 giorno
@@ -311,7 +309,6 @@ l
 la
 lasciato
 lato
-lavoro
 le
 lei
 li
@@ -331,8 +328,6 @@ mai
 male
 malgrado
 malissimo
-mancanza
-marche
 me
 medesimo
 mediante
@@ -358,8 +353,6 @@ moltissimo
 molto
 momento
 mondo
-mosto
-nazionale
 ne
 negl
 negli
@@ -645,7 +638,6 @@ varie
 vario
 verso
 vi
-via
 vicino
 visto
 vita


### PR DESCRIPTION
There are words that are very arbitrarily removed as stopwords probably because of weird homonymy when automatically translated in English